### PR TITLE
add filter using a raster method, remove flipud! from reduce

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ pointcloud = LazIO.open(lazfn)
 cellsizes = (1.,1.) #can also use [1.,1.]
 raster_index = index(pointcloud, cellsizes)
 
-#get some information about the index
+##get some information about the index:
 
 #the dataset the index was calculated from
 raster_index.ds
@@ -54,6 +54,14 @@ filter!(raster_index, last_return)
 ```
 Filters are done in-place and create a new index matching the condition. It does not change the loaded dataset.
 
+Filtering can also be done compared to a computed surface.
+For example, if we want to select all points within some tolerance of the median raster from above:
+
+```julia
+within_tol(p, raster_value) = isapprox(p.Z, raster_value, atol=5.0)
+filter!(idx, raster, within_tol)
+```
+
 ```julia
 # Reduce to raster
 raster = reduce(raster_index, field=:Z, reducer=median)
@@ -70,6 +78,7 @@ height_percentile = reduce(raster_index, field=:Z, reducer = x -> quantile(x,0.5
 Any reduced layer is returned as a [GeoArray](https://github.com/evetion/GeoArrays.jl). 
 
 ```julia
+
 #access the underlying data GeoArray
 raster.A
 #affine map information

--- a/src/PointCloudRasterizers.jl
+++ b/src/PointCloudRasterizers.jl
@@ -74,6 +74,28 @@ function Base.filter!(index::PointCloudIndex, condition=nothing)
 	end
 end
 
+"""Filter out index on given condition relative to a reduced layer."""
+function Base.filter!(index::PointCloudRasterizers.PointCloudIndex, raster::GeoArray, condition=nothing)
+
+    #check that size and affine info match
+    size(index.counts.A) == size(raster.A) || throw(DimensionMismatch("The sizes of the index and raster do not match."))
+    index.counts.f == raster.f || error("The affine information does not match")
+    index.counts.crs == raster.crs || error("The crs information does not match")
+
+    if condition != nothing
+        @showprogress 1 "Reducing points..." for (i, p) in enumerate(index.ds)
+            @inbounds ind = index.index[i]
+            ind == 0 && continue  # filtered point
+            raster_value = raster[ind]
+
+            if ~condition(p, raster_value)
+                @inbounds index.counts.A[ind] -= 1
+                @inbounds index.index[i] = 0
+            end
+        end
+    end
+end
+
 """Reduce multiple points to single value in given indexed pointcloud."""
 function Base.reduce(index::PointCloudIndex; field::Symbol=:Z, reducer=minimum, output_type=Float64)
 
@@ -122,7 +144,6 @@ function Base.reduce(index::PointCloudIndex; field::Symbol=:Z, reducer=minimum, 
 	end
 
 	ga = GeoArray(output, index.counts.f, index.counts.crs)
-	GeoArrays.flipud!(ga)  # move to GeoArrays
 	ga
 end
 

--- a/src/PointCloudRasterizers.jl
+++ b/src/PointCloudRasterizers.jl
@@ -77,7 +77,7 @@ end
 """Filter out index on given condition relative to a reduced layer."""
 function Base.filter!(index::PointCloudRasterizers.PointCloudIndex, raster::GeoArray, condition=nothing)
 
-    #check that size and affine info match
+    # check that size and affine info match
     size(index.counts.A) == size(raster.A) || throw(DimensionMismatch("The sizes of the index and raster do not match."))
     index.counts.f == raster.f || error("The affine information does not match")
     index.counts.crs == raster.crs || error("The crs information does not match")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -25,5 +25,8 @@ filter!(idx, last_return)
 # Reduce to raster
 raster = reduce(idx, field=:Z, reducer=median)
 
+within_tol(p, raster_value) = isapprox(p.Z, raster_value, atol=5.0)
+filter!(idx, raster, within_tol)
+
 # Save raster to tiff
 GeoArrays.write!("last_return_median.tif", raster)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -14,9 +14,9 @@ raster = reduce(idx, field=:Z, reducer=median)
 
 #indexing and reducing tests
 @test typeof(idx) == PointCloudRasterizers.PointCloudIndex
-@test count(ismissing,raster) == 24513458
+@test count(ismissing,raster) == 24503457
 @test count(!ismissing,raster) == 496543
-@test isapprox(mean(skipmissing(raster.A)),86154.22515270581 )
+@test isapprox(mean(skipmissing(raster.A)), 861.5422515270361)
 @test maximum(idx.counts) == 2
 
 #filtering tests

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,19 +12,19 @@ cellsizes = (1.,1.)
 idx = index(pointcloud, cellsizes)
 raster = reduce(idx, field=:Z, reducer=median)
 
-#indexing and reducing tests
+# indexing and reducing tests
 @test typeof(idx) == PointCloudRasterizers.PointCloudIndex
 @test count(ismissing,raster) == 24503457
 @test count(!ismissing,raster) == 496543
 @test isapprox(mean(skipmissing(raster.A)), 861.5422515270361)
 @test maximum(idx.counts) == 2
 
-#filtering tests
+# filtering tests
 last_return(p) = LazIO.return_number(p) == LazIO.number_of_returns(p)
 filter!(idx, last_return)
 @test sum(idx.counts) == 497534
 
-#file IO tests
+# file IO tests
 GeoArrays.write!("last_return_median.tif", raster)
 @test isfile("last_return_median.tif")
 rm("last_return_median.tif")


### PR DESCRIPTION
Closes #5 

This PR add a `Base.filter!(index::PointCloudRasterizers.PointCloudIndex, raster::GeoArray, condition=nothing)` method. 
I also removed the `flipud!` which was preventing this from working correctly. I also updated the README and tests.