### PR TITLE
Optimize performance

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PointCloudRasterizers"
 uuid = "971589f2-82d2-11e9-1393-93ab095f3ec7"
 authors = ["Maarten Pronk <git@evetion.nl>"]
-version = "0.2.6"
+version = "0.2.7"
 
 [deps]
 Dictionaries = "85a47980-9c8c-11e8-2b9f-f7ca1fa99fb4"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ PointCloudRasterizers is a Julia package for creating geographical raster images
 
 Use the Julia package manager (`]` in the REPL):
 ```julia
-(v1.8) pkg> add PointCloudRasterizers
+(v1.11) pkg> add PointCloudRasterizers
 ```
 
 ## Usage

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,7 +18,7 @@ crs = EPSG(4326)
         idx = index(pointcloud, cellsizes; crs=crs)
         index(collect(pointcloud), cellsizes; crs=crs, bbox=GeoInterface.extent(pointcloud))
         @inferred index(pointcloud, cellsizes; crs=crs)
-        @test typeof(idx) == PointCloudRasterizers.PointCloudIndex{LazIO.Dataset{0x00},Int}
+        @test typeof(idx) == PointCloudRasterizers.PointCloudIndex{LazIO.Dataset{0x00},UInt16}
         @test parent(idx) === pointcloud
         @test maximum(counts(idx)) == 2
         @test counts(idx).f.linear[1] == 1.0


### PR DESCRIPTION
- Reduces memory footprint (`UInt16` vs `Int64`)
- `reduce` now has faster paths for `min` and `max`
- `reduce` has a faster generic path when enough memory is available
- Improved type stability